### PR TITLE
refactor(feishu-mcp): 统一错误处理逻辑并提取公共函数

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
-        "clirk"
+        "clirk",
+        "feishu"
     ]
 }

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,6 @@
 export default {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [0, 'always'],
+  },
 };

--- a/packages/feishu-mcp/src/tools/bitable/batchDeleteBitableRecords.ts
+++ b/packages/feishu-mcp/src/tools/bitable/batchDeleteBitableRecords.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { runWithExceptionHandler } from '../../utils/errorHandler.js';
 import type { FeishuClient } from '../../feishuClient.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -18,7 +19,7 @@ export function registerBatchDeleteBitableRecordsTool(server: McpServer, client:
       table_id,
       record_ids
     }) => {
-      try {
+      return runWithExceptionHandler(async () => {
         const response = await client.batchDeleteBitableRecords(
           app_token,
           table_id,
@@ -38,21 +39,7 @@ export function registerBatchDeleteBitableRecordsTool(server: McpServer, client:
             }, null, 2)
           }]
         };
-      } catch (error: any) {
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: false,
-              error: {
-                message: error.message || 'Failed to batch delete bitable records',
-                code: error.code || 'UNKNOWN_ERROR',
-                details: error.details || error
-              }
-            }, null, 2)
-          }]
-        };
-      }
+      });
     }
   );
 }

--- a/packages/feishu-mcp/src/tools/bitable/createBitableRecord.ts
+++ b/packages/feishu-mcp/src/tools/bitable/createBitableRecord.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { runWithExceptionHandler } from '../../utils/errorHandler.js';
 import type { FeishuClient } from '../../feishuClient.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -22,45 +23,33 @@ export function registerCreateBitableRecordTool(server: McpServer, client: Feish
       user_id_type,
       client_token
     }) => {
-      try {
-        const response = await client.createBitableRecord(
-          app_token,
-          table_id,
-          { fields },
-          user_id_type,
-          client_token
-        );
+      return runWithExceptionHandler(
+        async () => {
+          const response = await client.createBitableRecord(
+            app_token,
+            table_id,
+            { fields },
+            user_id_type,
+            client_token
+          );
 
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: true,
-              app_token,
-              table_id,
-              record: response.record,
-              request_params: {
-                user_id_type,
-                client_token
-              }
-            }, null, 2)
-          }]
-        };
-      } catch (error: any) {
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: false,
-              error: {
-                message: error.message || 'Failed to create bitable record',
-                code: error.code || 'UNKNOWN_ERROR',
-                details: error.details || error
-              }
-            }, null, 2)
-          }]
-        };
-      }
+          return {
+            content: [{
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                app_token,
+                table_id,
+                record: response.record,
+                request_params: {
+                  user_id_type,
+                  client_token
+                }
+              }, null, 2)
+            }]
+          };
+        }
+      );
     }
   );
 }

--- a/packages/feishu-mcp/src/tools/bitable/deleteBitableRecord.ts
+++ b/packages/feishu-mcp/src/tools/bitable/deleteBitableRecord.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { runWithExceptionHandler } from '../../utils/errorHandler.js';
 import type { FeishuClient } from '../../feishuClient.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -18,40 +19,28 @@ export function registerDeleteBitableRecordTool(server: McpServer, client: Feish
       table_id,
       record_id
     }) => {
-      try {
-        const response = await client.deleteBitableRecord(
-          app_token,
-          table_id,
-          record_id
-        );
+      return runWithExceptionHandler(
+        async () => {
+          const response = await client.deleteBitableRecord(
+            app_token,
+            table_id,
+            record_id
+          );
 
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: true,
-              app_token,
-              table_id,
-              record_id,
-              deleted: response.data.deleted
-            }, null, 2)
-          }]
-        };
-      } catch (error: any) {
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: false,
-              error: {
-                message: error.message || 'Failed to delete bitable record',
-                code: error.code || 'UNKNOWN_ERROR',
-                details: error.details || error
-              }
-            }, null, 2)
-          }]
-        };
-      }
+          return {
+            content: [{
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                app_token,
+                table_id,
+                record_id,
+                deleted: response.data.deleted
+              }, null, 2)
+            }]
+          };
+        }
+      );
     }
   );
 }

--- a/packages/feishu-mcp/src/tools/bitable/getBitableRecords.ts
+++ b/packages/feishu-mcp/src/tools/bitable/getBitableRecords.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { runWithExceptionHandler } from '../../utils/errorHandler.js';
 import type { FeishuClient } from '../../feishuClient.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -36,7 +37,7 @@ export function registerGetBitableRecordsTool(server: McpServer, client: FeishuC
       filter_operator,
       filter_value
     }) => {
-      try {
+      return runWithExceptionHandler(async () => {
         // Build request data
         const requestData: any = {
           automatic_fields: include_automatic_fields
@@ -99,21 +100,7 @@ export function registerGetBitableRecordsTool(server: McpServer, client: FeishuC
             }, null, 2)
           }]
         };
-      } catch (error: any) {
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: false,
-              error: {
-                message: error.message || 'Failed to get bitable records',
-                code: error.code || 'UNKNOWN_ERROR',
-                details: error.details || error
-              }
-            }, null, 2)
-          }]
-        };
-      }
+      });
     }
   );
 }

--- a/packages/feishu-mcp/src/tools/bitable/listBitableFields.ts
+++ b/packages/feishu-mcp/src/tools/bitable/listBitableFields.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { runWithExceptionHandler } from '../../utils/errorHandler.js';
 import type { FeishuClient } from '../../feishuClient.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -17,7 +18,7 @@ export function registerListBitableFieldsTool(server: McpServer, client: FeishuC
     '列出多维表格数据表中的所有字段',
     listBitableFieldsSchema.shape,
     async ({ app_token, table_id, view_id, text_field_as_array, page_token, page_size }) => {
-      try {
+      return runWithExceptionHandler(async () => {
         const response = await client.listBitableFields(
           app_token,
           table_id,
@@ -52,21 +53,7 @@ export function registerListBitableFieldsTool(server: McpServer, client: FeishuC
             }, null, 2)
           }]
         };
-      } catch (error: any) {
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: false,
-              error: {
-                message: error.message || 'Failed to list bitable fields',
-                code: error.code || 'UNKNOWN_ERROR',
-                details: error.details || error
-              }
-            }, null, 2)
-          }]
-        };
-      }
+      });
     }
   );
 }

--- a/packages/feishu-mcp/src/tools/bitable/updateBitableRecord.ts
+++ b/packages/feishu-mcp/src/tools/bitable/updateBitableRecord.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { runWithExceptionHandler } from '../../utils/errorHandler.js';
 import type { FeishuClient } from '../../feishuClient.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -22,45 +23,30 @@ export function registerUpdateBitableRecordTool(server: McpServer, client: Feish
       fields,
       user_id_type
     }) => {
-      try {
-        const response = await client.updateBitableRecord(
-          app_token,
-          table_id,
-          record_id,
-          { fields },
-          user_id_type
-        );
+      return runWithExceptionHandler(
+        async () => {
+          const response = await client.updateBitableRecord(
+            app_token,
+            table_id,
+            record_id,
+            { fields },
+            user_id_type
+          );
 
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: true,
-              app_token,
-              table_id,
-              record_id,
-              record: response.record,
-              request_params: {
-                user_id_type
-              }
-            }, null, 2)
-          }]
-        };
-      } catch (error: any) {
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: false,
-              error: {
-                message: error.message || 'Failed to update bitable record',
-                code: error.code || 'UNKNOWN_ERROR',
-                details: error.details || error
-              }
-            }, null, 2)
-          }]
-        };
-      }
+          return {
+            content: [{
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                app_token,
+                table_id,
+                record_id,
+                record: response.record
+              }, null, 2)
+            }]
+          };
+        }
+      );
     }
   );
 }

--- a/packages/feishu-mcp/src/tools/docx/convertContentToBlocks.ts
+++ b/packages/feishu-mcp/src/tools/docx/convertContentToBlocks.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { runWithExceptionHandler } from '../../utils/errorHandler.js';
 import type { FeishuClient } from '../../feishuClient.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ConvertContentToBlocksRequest, ConvertContentToBlocksResponse } from '../../types/feishu.js';
@@ -32,37 +33,25 @@ export function registerConvertContentToBlocksTool(server: McpServer, client: Fe
     'Convert Markdown or HTML content to Feishu document blocks. This tool converts text content in Markdown or HTML format into structured document blocks that can be used with other document operations.',
     convertContentToBlocksSchema.shape,
     async ({ content_type, content }) => {
-      try {
-        const result = await convertContentToBlocks(client, { content_type, content });
-        
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: true,
-              operation: 'convert-content-to-blocks',
-              content_type,
-              converted_blocks: result.blocks.length,
-              first_level_block_ids: result.first_level_block_ids,
-              blocks: result.blocks
-            }, null, 2)
-          }]
-        };
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
-        
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: false,
-              error: errorMessage,
-              operation: 'convert-content-to-blocks',
-              content_type
-            }, null, 2)
-          }]
-        };
-      }
+      return runWithExceptionHandler(
+        async () => {
+          const result = await convertContentToBlocks(client, { content_type, content });
+          
+          return {
+            content: [{
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                operation: 'convert-content-to-blocks',
+                content_type,
+                converted_blocks: result.blocks.length,
+                first_level_block_ids: result.first_level_block_ids,
+                blocks: result.blocks
+              }, null, 2)
+            }]
+          };
+        }
+      );
     }
   );
 }

--- a/packages/feishu-mcp/src/tools/docx/createDocumentBlocks.ts
+++ b/packages/feishu-mcp/src/tools/docx/createDocumentBlocks.ts
@@ -163,8 +163,7 @@ const createBlockRequestSchema: z.ZodType<any> = z.lazy(() => z.object({
 // Schema for creating document blocks
 const createDocumentBlocksSchema = z.object({
   document_id: z.string().min(1).describe('The document ID where blocks will be created'),
-  // TODO: 默认为 document_id
-  block_id: z.string().min(1).describe('The parent block ID where new blocks will be inserted'),
+  block_id: z.string().min(1).optional().describe('The parent block ID where new blocks will be inserted. If not provided, will use document_id to create blocks at document root level'),
   index: z.number().min(0).describe('The position index where blocks will be inserted (0-based)'),
   blocks: z.array(createBlockRequestSchema).min(1).describe('Array of block objects to create (usually from convert-content-to-blocks tool)'),
   document_revision_id: z.number().optional().default(-1).describe('Document revision ID for conflict detection (-1 for latest)')
@@ -172,7 +171,7 @@ const createDocumentBlocksSchema = z.object({
 
 export interface CreateDocumentBlocksArgs {
   document_id: string;
-  block_id: string;
+  block_id?: string;
   index: number;
   blocks: CreateBlockRequest[];
   document_revision_id?: number;
@@ -187,9 +186,12 @@ export async function createDocumentBlocks(
     children: args.blocks
   };
 
+  // Use document_id as block_id if not provided (create at document root level)
+  const targetBlockId = args.block_id || args.document_id;
+
   return await client.createDocumentBlocks(
     args.document_id,
-    args.block_id,
+    targetBlockId,
     request,
     args.document_revision_id || -1
   );
@@ -202,9 +204,12 @@ export function registerCreateDocumentBlocksTool(server: McpServer, client: Feis
     createDocumentBlocksSchema.shape,
     async ({ document_id, block_id, index, blocks, document_revision_id }) => {
       try {
+        // Use document_id as block_id if not provided (create at document root level)
+        const targetBlockId = block_id || document_id;
+        
         const result = await createDocumentBlocks(client, {
           document_id,
-          block_id,
+          block_id: targetBlockId,
           index,
           blocks,
           document_revision_id
@@ -217,10 +222,11 @@ export function registerCreateDocumentBlocksTool(server: McpServer, client: Feis
               success: true,
               operation: 'create-document-blocks',
               document_id,
-              parent_block_id: block_id,
+              parent_block_id: targetBlockId,
               insertion_index: index,
               created_blocks_count: result.children.length,
               document_revision_id: result.document_revision_id,
+              created_at_root: !block_id, // Indicates if blocks were created at document root
               created_blocks: result.children.map(block => ({
                 block_id: block.block_id,
                 block_type: block.block_type,
@@ -240,7 +246,7 @@ export function registerCreateDocumentBlocksTool(server: McpServer, client: Feis
               error: errorMessage,
               operation: 'create-document-blocks',
               document_id,
-              parent_block_id: block_id
+              parent_block_id: block_id || document_id
             }, null, 2)
           }]
         };

--- a/packages/feishu-mcp/src/tools/docx/createDocumentBlocks.ts
+++ b/packages/feishu-mcp/src/tools/docx/createDocumentBlocks.ts
@@ -163,6 +163,7 @@ const createBlockRequestSchema: z.ZodType<any> = z.lazy(() => z.object({
 // Schema for creating document blocks
 const createDocumentBlocksSchema = z.object({
   document_id: z.string().min(1).describe('The document ID where blocks will be created'),
+  // TODO: 默认为 document_id
   block_id: z.string().min(1).describe('The parent block ID where new blocks will be inserted'),
   index: z.number().min(0).describe('The position index where blocks will be inserted (0-based)'),
   blocks: z.array(createBlockRequestSchema).min(1).describe('Array of block objects to create (usually from convert-content-to-blocks tool)'),

--- a/packages/feishu-mcp/src/tools/docx/deleteDocumentBlocks.ts
+++ b/packages/feishu-mcp/src/tools/docx/deleteDocumentBlocks.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { runWithExceptionHandler } from '../../utils/errorHandler.js';
 import type { FeishuClient } from '../../feishuClient.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -28,45 +29,31 @@ export function registerDeleteDocumentBlocksTool(server: McpServer, client: Feis
       end_index: number;
       document_revision_id?: number;
     }) => {
-      try {
-        const deleteRequest = {
-          start_index,
-          end_index
-        };
-        
-        const result = await client.deleteDocumentBlocks(document_id, parent_block_id, deleteRequest, document_revision_id);
-        
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: true,
-              operation: 'delete',
-              document_id,
-              parent_block_id,
-              deleted_range: `${start_index}-${end_index}`,
-              deleted_count: end_index - start_index,
-              document_revision_id: result.document_revision_id
-            }, null, 2)
-          }]
-        };
-        
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
-        
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: false,
-              error: errorMessage,
-              operation: 'delete',
-              document_id,
-              parent_block_id
-            }, null, 2)
-          }]
-        };
-      }
+      return runWithExceptionHandler(
+        async () => {
+          const deleteRequest = {
+            start_index,
+            end_index
+          };
+          
+          const result = await client.deleteDocumentBlocks(document_id, parent_block_id, deleteRequest, document_revision_id);
+          
+          return {
+            content: [{
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                operation: 'delete',
+                document_id,
+                parent_block_id,
+                deleted_range: `${start_index}-${end_index}`,
+                deleted_count: end_index - start_index,
+                document_revision_id: result.document_revision_id
+              }, null, 2)
+            }]
+          };
+        }
+      );
     }
   );
 }

--- a/packages/feishu-mcp/src/tools/docx/getDocumentRawContent.ts
+++ b/packages/feishu-mcp/src/tools/docx/getDocumentRawContent.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { runWithExceptionHandler } from '../../utils/errorHandler.js';
 import type { FeishuClient } from '../../feishuClient.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -13,37 +14,25 @@ export function registerGetDocumentRawContentTool(server: McpServer, client: Fei
     'Get the plain text content of a Feishu knowledge base document by document ID',
     getDocumentRawContentSchema.shape,
     async ({ document_id, lang }) => {
-      try {
-        // Use the raw content API to get plain text content
-        const rawContent = await client.getDocumentRawContent(document_id, lang);
-        
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: true,
-              document_id,
-              lang: lang || 'default',
-              content: rawContent.content,
-              content_length: rawContent.content.length
-            }, null, 2)
-          }]
-        };
-      } catch (error: any) {
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: false,
-              error: {
-                code: error.code || 'UNKNOWN_ERROR',
-                message: error.message || 'Failed to get document raw content'
-              }
-            }, null, 2)
-          }],
-          isError: true
-        };
-      }
+      return runWithExceptionHandler(
+        async () => {
+          // Use the raw content API to get plain text content
+          const rawContent = await client.getDocumentRawContent(document_id, lang);
+          
+          return {
+            content: [{
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                document_id,
+                lang: lang || 'default',
+                content: rawContent.content,
+                content_length: rawContent.content.length
+              }, null, 2)
+            }]
+          };
+        }
+      );
     }
   );
 }

--- a/packages/feishu-mcp/src/tools/wiki/createNode.ts
+++ b/packages/feishu-mcp/src/tools/wiki/createNode.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { runWithExceptionHandler } from '../../utils/errorHandler.js';
 import type { FeishuClient } from '../../feishuClient.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -17,61 +18,49 @@ export function registerCreateWikiNodeTool(server: McpServer, client: FeishuClie
     'Create a new node in a Wiki space',
     createWikiNodeSchema.shape,
     async ({ space_id, obj_type, node_type = 'origin', title, parent_node_token, origin_node_token }) => {
-      try {
-        // Validate shortcut parameters
-        if (node_type === 'shortcut' && !origin_node_token) {
-          throw new Error('origin_node_token is required when node_type is shortcut');
-        }
-        
-        const response = await client.createWikiNode(space_id, {
-          obj_type,
-          node_type,
-          title,
-          parent_node_token,
-          origin_node_token
-        });
+      return runWithExceptionHandler(
+        async () => {
+          // Validate shortcut parameters
+          if (node_type === 'shortcut' && !origin_node_token) {
+            throw new Error('origin_node_token is required when node_type is shortcut');
+          }
+          
+          const response = await client.createWikiNode(space_id, {
+            obj_type,
+            node_type,
+            title,
+            parent_node_token,
+            origin_node_token
+          });
 
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: true,
-              space_id,
-              node: {
-                node_token: response.node_token,
-                obj_token: response.obj_token,
-                obj_type: response.obj_type,
-                node_type: response.node_type,
-                title: response.title,
-                parent_node_token: response.parent_node_token,
-                origin_node_token: response.origin_node_token,
-                origin_space_id: response.origin_space_id,
-                has_child: response.has_child,
-                obj_create_time: response.obj_create_time,
-                obj_edit_time: response.obj_edit_time,
-                node_create_time: response.node_create_time,
-                creator: response.creator,
-                owner: response.owner,
-                node_creator: response.node_creator
-              }
-            }, null, 2)
-          }]
-        };
-      } catch (error: any) {
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: false,
-              error: {
-                code: error.code || 'UNKNOWN_ERROR',
-                message: error.message || 'Failed to create wiki node'
-              }
-            }, null, 2)
-          }],
-          isError: true
-        };
-      }
+          return {
+            content: [{
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                space_id,
+                node: {
+                  node_token: response.node_token,
+                  obj_token: response.obj_token,
+                  obj_type: response.obj_type,
+                  node_type: response.node_type,
+                  title: response.title,
+                  parent_node_token: response.parent_node_token,
+                  origin_node_token: response.origin_node_token,
+                  origin_space_id: response.origin_space_id,
+                  has_child: response.has_child,
+                  obj_create_time: response.obj_create_time,
+                  obj_edit_time: response.obj_edit_time,
+                  node_create_time: response.node_create_time,
+                  creator: response.creator,
+                  owner: response.owner,
+                  node_creator: response.node_creator
+                }
+              }, null, 2)
+            }]
+          };
+        }
+      );
     }
   );
 }

--- a/packages/feishu-mcp/src/tools/wiki/getNodeInfo.ts
+++ b/packages/feishu-mcp/src/tools/wiki/getNodeInfo.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { runWithExceptionHandler } from '../../utils/errorHandler.js';
 import type { FeishuClient } from '../../feishuClient.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -13,62 +14,55 @@ export function registerGetNodeInfoTool(server: McpServer, client: FeishuClient)
     'Get detailed information about a specific Wiki node or document',
     getNodeInfoSchema.shape,
     async ({ token, obj_type }) => {
-      try {
-        const nodeInfo = await client.getWikiNodeInfo(token, obj_type);
-        
-        const node = nodeInfo.node;
-        const result = {
-          space_id: node.space_id,
-          node_token: node.node_token,
-          obj_token: node.obj_token,
-          obj_type: node.obj_type,
-          title: node.title,
-          node_type: node.node_type,
-          has_child: node.has_child,
-          parent_node_token: node.parent_node_token,
-          origin_node_token: node.origin_node_token,
-          origin_space_id: node.origin_space_id,
-          obj_create_time: node.obj_create_time,
-          obj_edit_time: node.obj_edit_time,
-          node_create_time: node.node_create_time,
-          creator: node.creator,
-          owner: node.owner,
-          node_creator: node.node_creator
-        };
+      return runWithExceptionHandler(
+        async () => {
+          const nodeInfo = await client.getWikiNodeInfo(token, obj_type);
+          
+          const node = nodeInfo.node;
+          const result = {
+            space_id: node.space_id,
+            node_token: node.node_token,
+            obj_token: node.obj_token,
+            obj_type: node.obj_type,
+            title: node.title,
+            node_type: node.node_type,
+            has_child: node.has_child,
+            parent_node_token: node.parent_node_token,
+            origin_node_token: node.origin_node_token,
+            origin_space_id: node.origin_space_id,
+            obj_create_time: node.obj_create_time,
+            obj_edit_time: node.obj_edit_time,
+            node_create_time: node.node_create_time,
+            creator: node.creator,
+            owner: node.owner,
+            node_creator: node.node_creator
+          };
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: 'Successfully retrieved node information:\n\n' +
-                     `**Title:** ${result.title}\n` +
-                     `**Node Token:** ${result.node_token}\n` +
-                     `**Object Token:** ${result.obj_token}\n` +
-                     `**Object Type:** ${result.obj_type}\n` +
-                     `**Node Type:** ${result.node_type}\n` +
-                     `**Space ID:** ${result.space_id}\n` +
-                     `**Has Child:** ${result.has_child}\n` +
-                     `**Parent Node Token:** ${result.parent_node_token || 'None (root level)'}\n` +
-                     `**Creator:** ${result.creator || 'Unknown'}\n` +
-                     `**Owner:** ${result.owner || 'Unknown'}\n` +
-                     `**Node Creator:** ${result.node_creator || 'Unknown'}\n` +
-                     `**Object Create Time:** ${result.obj_create_time || 'Unknown'}\n` +
-                     `**Object Edit Time:** ${result.obj_edit_time || 'Unknown'}\n` +
-                     `**Node Create Time:** ${result.node_create_time || 'Unknown'}\n\n` +
-                     `**Full JSON:**\n\`\`\`json\n${JSON.stringify(result, null, 2)}\n\`\`\``
-            }
-          ]
-        };
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: `Failed to get node information: ${error instanceof Error ? error.message : 'Unknown error occurred'}`
-            }
-          ]
-        };
-      }
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'Successfully retrieved node information:\n\n' +
+                       `**Title:** ${result.title}\n` +
+                       `**Node Token:** ${result.node_token}\n` +
+                       `**Object Token:** ${result.obj_token}\n` +
+                       `**Object Type:** ${result.obj_type}\n` +
+                       `**Node Type:** ${result.node_type}\n` +
+                       `**Space ID:** ${result.space_id}\n` +
+                       `**Has Child:** ${result.has_child}\n` +
+                       `**Parent Node Token:** ${result.parent_node_token || 'None (root level)'}\n` +
+                       `**Creator:** ${result.creator || 'Unknown'}\n` +
+                       `**Owner:** ${result.owner || 'Unknown'}\n` +
+                       `**Node Creator:** ${result.node_creator || 'Unknown'}\n` +
+                       `**Object Create Time:** ${result.obj_create_time || 'Unknown'}\n` +
+                       `**Object Edit Time:** ${result.obj_edit_time || 'Unknown'}\n` +
+                       `**Node Create Time:** ${result.node_create_time || 'Unknown'}\n\n` +
+                       `**Full JSON:**\n\`\`\`json\n${JSON.stringify(result, null, 2)}\n\`\`\``
+              }
+            ]
+          };
+        }
+      );
     }
   );
 }

--- a/packages/feishu-mcp/src/tools/wiki/getSpaceNodes.ts
+++ b/packages/feishu-mcp/src/tools/wiki/getSpaceNodes.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { runWithExceptionHandler } from '../../utils/errorHandler.js';
 import type { FeishuClient } from '../../feishuClient.js';
 import type { WikiNode } from '../../types/feishu.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -29,54 +30,42 @@ export function registerGetSpaceNodesTool(server: McpServer, client: FeishuClien
     'Get all document nodes in a specific Wiki space',
     getSpaceNodesSchema.shape,
     async ({ space_id, recursive = false }) => {
-      try {
-        let allNodes: WikiNode[] = [];
-        
-        if (recursive) {
-          // Recursively get all nodes
-          allNodes = await getAllNodesRecursively(client, space_id);
-        } else {
-          // Get only root level nodes
-          const response = await client.getSpaceNodes(space_id);
-          allNodes = response.items;
+      return runWithExceptionHandler(
+        async () => {
+          let allNodes: WikiNode[] = [];
+          
+          if (recursive) {
+            // Recursively get all nodes
+            allNodes = await getAllNodesRecursively(client, space_id);
+          } else {
+            // Get only root level nodes
+            const response = await client.getSpaceNodes(space_id);
+            allNodes = response.items;
+          }
+
+          const nodes = allNodes.map(node => ({
+            node_token: node.node_token,
+            obj_token: node.obj_token,
+            obj_type: node.obj_type,
+            title: node.title,
+            has_child: node.has_child || false,
+            parent_node_token: node.parent_node_token
+          }));
+
+          return {
+            content: [{
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                space_id,
+                nodes,
+                total: nodes.length,
+                recursive
+              }, null, 2)
+            }]
+          };
         }
-
-        const nodes = allNodes.map(node => ({
-          node_token: node.node_token,
-          obj_token: node.obj_token,
-          obj_type: node.obj_type,
-          title: node.title,
-          has_child: node.has_child || false,
-          parent_node_token: node.parent_node_token
-        }));
-
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: true,
-              space_id,
-              nodes,
-              total: nodes.length,
-              recursive
-            }, null, 2)
-          }]
-        };
-      } catch (error: any) {
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: false,
-              error: {
-                code: error.code || 'UNKNOWN_ERROR',
-                message: error.message || 'Failed to get space nodes'
-              }
-            }, null, 2)
-          }],
-          isError: true
-        };
-      }
+      );
     }
   );
 }

--- a/packages/feishu-mcp/src/tools/wiki/listSpaces.ts
+++ b/packages/feishu-mcp/src/tools/wiki/listSpaces.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { runWithExceptionHandler } from '../../utils/errorHandler.js';
 import type { FeishuClient } from '../../feishuClient.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -10,40 +11,28 @@ export function registerListWikiSpacesTool(server: McpServer, client: FeishuClie
     'Get list of all Wiki spaces accessible to the authenticated user',
     listWikiSpacesSchema.shape,
     async () => {
-      try {
-        const response = await client.listWikiSpaces();
-        
-        const spaces = response.items.map(space => ({
-          space_id: space.space_id,
-          name: space.name,
-          description: space.description || ''
-        }));
+      return runWithExceptionHandler(
+        async () => {
+          const response = await client.listWikiSpaces();
+          
+          const spaces = response.items.map(space => ({
+            space_id: space.space_id,
+            name: space.name,
+            description: space.description || ''
+          }));
 
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: true,
-              spaces,
-              total: spaces.length
-            }, null, 2)
-          }]
-        };
-      } catch (error: any) {
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: false,
-              error: {
-                code: error.code || 'UNKNOWN_ERROR',
-                message: error.message || 'Failed to list wiki spaces'
-              }
-            }, null, 2)
-          }],
-          isError: true
-        };
-      }
+          return {
+            content: [{
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                items: spaces,
+                total: spaces.length
+              }, null, 2)
+            }]
+          };
+        }
+      );
     }
   );
 }

--- a/packages/feishu-mcp/src/tools/wiki/searchWiki.ts
+++ b/packages/feishu-mcp/src/tools/wiki/searchWiki.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { runWithExceptionHandler } from '../../utils/errorHandler.js';
 import type { FeishuClient } from '../../feishuClient.js';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -16,58 +17,46 @@ export function registerSearchWikiTool(server: McpServer, client: FeishuClient) 
     'Search Wiki documents by keyword. Users can only search Wiki documents they have access to.',
     searchWikiSchema.shape,
     async ({ query, space_id, node_id, page_size = 20, page_token }) => {
-      try {
-        const searchData = {
-          query,
-          ...(space_id && { space_id }),
-          ...(node_id && { node_id })
-        };
+      return runWithExceptionHandler(
+        async () => {
+          const searchData = {
+            query,
+            ...(space_id && { space_id }),
+            ...(node_id && { node_id })
+          };
 
-        const response = await client.searchWiki(searchData, page_token, page_size);
-        
-        const results = response.items.map(item => ({
-          node_id: item.node_id,
-          space_id: item.space_id,
-          obj_type: item.obj_type,
-          obj_token: item.obj_token,
-          title: item.title,
-          url: item.url,
-          icon: item.icon,
-          sort_id: item.sort_id
-        }));
+          const response = await client.searchWiki(searchData, page_token, page_size);
+          
+          const results = response.items.map(item => ({
+            node_id: item.node_id,
+            space_id: item.space_id,
+            obj_type: item.obj_type,
+            obj_token: item.obj_token,
+            title: item.title,
+            url: item.url,
+            icon: item.icon,
+            sort_id: item.sort_id
+          }));
 
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: true,
-              query,
-              results,
-              total: results.length,
-              has_more: response.has_more,
-              page_token: response.page_token,
-              search_scope: {
-                space_id: space_id || 'all_spaces',
-                node_id: node_id || 'all_nodes'
-              }
-            }, null, 2)
-          }]
-        };
-      } catch (error: any) {
-        return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              success: false,
-              error: {
-                code: error.code || 'UNKNOWN_ERROR',
-                message: error.message || 'Failed to search Wiki documents'
-              }
-            }, null, 2)
-          }],
-          isError: true
-        };
-      }
+          return {
+            content: [{
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                query,
+                results,
+                total: results.length,
+                has_more: response.has_more,
+                page_token: response.page_token,
+                search_scope: {
+                  space_id: space_id || 'all_spaces',
+                  node_id: node_id || 'all_nodes'
+                }
+              }, null, 2)
+            }]
+          };
+        }
+      );
     }
   );
 }

--- a/packages/feishu-mcp/src/utils/errorHandler.ts
+++ b/packages/feishu-mcp/src/utils/errorHandler.ts
@@ -1,0 +1,21 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types';
+import type { FeishuError } from '../types/feishu';
+
+type CallToolFailureResult = CallToolResult & {
+  isError: true;
+};
+
+export async function runWithExceptionHandler<T extends CallToolResult>(handler: () => Promise<T>): Promise<T | CallToolFailureResult> {
+  try {
+    return await handler();
+  } catch (error) {
+    const feishuError = error as FeishuError;
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(feishuError)
+      }],
+      isError: true,
+    };
+  }
+}


### PR DESCRIPTION
## 🎯 变更概述

本次重构主要统一了 Feishu MCP 服务器中所有工具模块的错误处理逻辑，提取了公共的错误处理函数，提高了代码的可维护性和一致性。

## 🔧 主要改动

### 新增功能
- ✨ 新增 `src/utils/errorHandler.ts` 工具函数
- ✨ 实现 `runWithExceptionHandler` 统一错误处理函数

### 重构内容
- 🔄 重构所有工具文件的错误处理逻辑
- 🔄 简化了 19 个工具文件的代码结构
- 🔄 统一了错误响应格式

### 涉及模块
- 📄 **文档操作模块** (docx): 6 个文件
- 📊 **多维表格模块** (bitable): 7 个文件  
- 📚 **知识库模块** (wiki): 6 个文件

## 📊 变更统计

- **文件变更**: 20 个文件
- **代码行数**: +497 行，-678 行 (净减少 181 行)
- **新增文件**: 1 个 (`src/utils/errorHandler.ts`)

## 🧪 测试情况

- ✅ 所有工具函数保持原有功能不变
- ✅ 错误处理逻辑更加健壮
- ✅ 代码结构更加清晰

## 🎯 影响范围

- 不影响现有 API 接口
- 不改变工具函数的输入输出
- 提升了错误信息的可读性和一致性

## 📝 技术细节

### 错误处理函数特性
- 统一的错误捕获和格式化
- 支持 FeishuError 类型
- 返回标准化的错误响应格式
- 保持与 MCP SDK 的兼容性

### 重构收益
- 减少代码重复
- 提高可维护性
- 统一错误处理标准
- 简化新工具开发