### PR TITLE
refactor: 重命名 logger.ts 为 verbose.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemons/mcp-servers",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Unified MCP Servers CLI",
   "license": "MIT",
   "author": "MCP Servers Team",

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -27,7 +27,7 @@ export async function runAction(serverName: string, verbose: boolean = false): P
   
   let spawnArgs: string[];
   if (verbose) {
-    const loggerPath = path.join(__dirname, '..', 'logger.ts');
+    const loggerPath = path.join(__dirname, '..', 'verbose.ts');
     spawnArgs = ['tsx', loggerPath, 'tsx', serverRunnerPath, serverName];
     console.log('📝 启用详细日志记录');
   } else {

--- a/src/verbose.ts
+++ b/src/verbose.ts
@@ -13,7 +13,7 @@ const __filename = fileURLToPath(import.meta.url);
 // 计算日志文件路径：输出到项目根目录的logger目录下，按照<server-name>.log格式命名
 function getLogFilePath(): string {
   // 从命令行参数中提取server-name (process.argv[4])
-  // 参数格式：node logger.ts tsx runner.ts <server-name>
+  // 参数格式：node verbose.ts tsx runner.ts <server-name>
   const serverName = process.argv[4];
   
   if (!serverName) {
@@ -38,7 +38,7 @@ function getLogFilePath(): string {
 
 // 获取项目根目录
 function getProjectRoot(): string {
-  // 当前文件在 src/logger.ts，所以项目根目录是上一级
+  // 当前文件在 src/verbose.ts，所以项目根目录是上一级
   return path.dirname(path.dirname(__filename));
 }
 


### PR DESCRIPTION
## 变更说明

将日志记录器文件从 `logger.ts` 重命名为 `verbose.ts`，以更准确地反映其作为详细日志输出工具的用途。

## 变更内容

- 📁 重命名文件: `src/logger.ts` → `src/verbose.ts`
- 🔄 更新所有相关引用和导入路径
- 📝 更新注释中的文件名引用

## 测试

- ✅ 所有 lint 检查通过
- ✅ 文件重命名后引用正确更新